### PR TITLE
Use the geo.mirror.pkgbuild.com mirror

### DIFF
--- a/packer.json
+++ b/packer.json
@@ -1,7 +1,7 @@
 {
     "variables": {
-        "iso_url": "https://mirror.pkgbuild.com/iso/latest/archlinux-{{isotime \"2006.01\"}}.01-x86_64.iso",
-        "iso_checksum_url": "https://mirror.pkgbuild.com/iso/latest/sha1sums.txt",
+        "iso_url": "https://geo.mirror.pkgbuild.com/iso/latest/archlinux-{{isotime \"2006.01\"}}.01-x86_64.iso",
+        "iso_checksum_url": "https://geo.mirror.pkgbuild.com/iso/latest/sha1sums.txt",
         "disk_size": "20480",
         "headless": "true",
         "boot_wait": "60s",


### PR DESCRIPTION
geo.mirror.pkgbuild.com is a GeoDNS mirror that points to sponsored mirrors.

This avoids the usage of Arch's infrastructure (mirror.pkgbuild.com) for large downloads.
See https://gitlab.archlinux.org/archlinux/infrastructure/-/merge_requests/522 for details.

----
Basically the same as https://github.com/BlackIkeEagle/archlinux-reinstall/pull/8.